### PR TITLE
Version 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,25 @@
 # Changelog
 
+## 2.0.0
+
+New features:
+ * Add a static function to update the Collection of entities with an input array.
+ * Changing the `except` option for the `UniqueEntityData` constraint to support the Expression language.
+ * In case of violations from the ParamConverter, the returned value is directly an array of violations instead of a message with the violations formatted in JSON.
+ * It is possible to use the tag `app.data_transfer_object` to declare DTO instead of using the `@DTO` annotation.
+ 
+Breaking changes:
+ * By changing the `except` option for the `UniqueEntityData` constraint, it is now mandatory to use `this` to target a property withing the DTO (e.g. `this.targetEntity`).
+ * In case of violations, the returned value changed from a message with a JSON encoded string to an array of violations.
+
+
 ## 1.0.1
 
 Bug fixes:
  * Validates only the top level Data Transfer Object (DTO), not the nested DTO.
  * Fix the creation of a collection of a DTO.
  * Fix the `UniqueEntityClass` service when no `EntityManager` is configured.
+ 
 
 ## 1.0.0
 

--- a/ChapleanDtoHandlerBundle.php
+++ b/ChapleanDtoHandlerBundle.php
@@ -11,6 +11,8 @@
 
 namespace Chaplean\Bundle\DtoHandlerBundle;
 
+use Chaplean\Bundle\DtoHandlerBundle\DependencyInjection\Compiler\DataTransferObjectPass;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 /**
@@ -23,4 +25,13 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
  */
 class ChapleanDtoHandlerBundle extends Bundle
 {
+    /**
+     * @param ContainerBuilder $container
+     *
+     * @return void
+     */
+    public function build(ContainerBuilder $container)
+    {
+        $container->addCompilerPass(new DataTransferObjectPass());
+    }
 }

--- a/ConfigurationExtractor/PropertyConfigurationExtractor.php
+++ b/ConfigurationExtractor/PropertyConfigurationExtractor.php
@@ -14,9 +14,10 @@ namespace Chaplean\Bundle\DtoHandlerBundle\ConfigurationExtractor;
 use Chaplean\Bundle\DtoHandlerBundle\Annotation\MapTo;
 use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationReader;
-use Doctrine\ORM\Mapping\Entity;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\Validator\Constraints\All;
+use Symfony\Component\Validator\Constraints\Date;
+use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
@@ -77,6 +78,10 @@ class PropertyConfigurationExtractor
         $arrayAnnotation = $annotationReader->getPropertyAnnotation($property, All::class);
         /** @var Type $typeAnnotation */
         $typeAnnotation = $annotationReader->getPropertyAnnotation($property, Type::class);
+        /** @var Date $dateAnnotation */
+        $dateAnnotation = $annotationReader->getPropertyAnnotation($property, Date::class);
+        /** @var DateTime $dateTimeAnnotation */
+        $dateTimeAnnotation = $annotationReader->getPropertyAnnotation($property, DateTime::class);
         /** @var MapTo $mapToAnnotation */
         $mapToAnnotation = $annotationReader->getPropertyAnnotation($property, MapTo::class);
         /** @var NotNull $notNullAnnotation */
@@ -94,7 +99,7 @@ class PropertyConfigurationExtractor
              $typeAnnotation = $this->findTypeConstraint($arrayAnnotation) ?? $typeAnnotation;
         }
 
-        if ($typeAnnotation !== null && class_exists($typeAnnotation->type)) {
+        if ($typeAnnotation !== null && \class_exists($typeAnnotation->type)) {
             $this->type = $typeAnnotation->type;
         }
     }

--- a/ConfigurationExtractor/PropertyConfigurationExtractor.php
+++ b/ConfigurationExtractor/PropertyConfigurationExtractor.php
@@ -16,8 +16,6 @@ use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\Validator\Constraints\All;
-use Symfony\Component\Validator\Constraints\Date;
-use Symfony\Component\Validator\Constraints\DateTime;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Constraints\Type;
@@ -78,10 +76,6 @@ class PropertyConfigurationExtractor
         $arrayAnnotation = $annotationReader->getPropertyAnnotation($property, All::class);
         /** @var Type $typeAnnotation */
         $typeAnnotation = $annotationReader->getPropertyAnnotation($property, Type::class);
-        /** @var Date $dateAnnotation */
-        $dateAnnotation = $annotationReader->getPropertyAnnotation($property, Date::class);
-        /** @var DateTime $dateTimeAnnotation */
-        $dateTimeAnnotation = $annotationReader->getPropertyAnnotation($property, DateTime::class);
         /** @var MapTo $mapToAnnotation */
         $mapToAnnotation = $annotationReader->getPropertyAnnotation($property, MapTo::class);
         /** @var NotNull $notNullAnnotation */

--- a/DependencyInjection/Compiler/DataTransferObjectPass.php
+++ b/DependencyInjection/Compiler/DataTransferObjectPass.php
@@ -10,8 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * Class DataTransferObjectPass
  *
  * @package   Chaplean\Bundle\DtoHandlerBundle\DependencyInjection\Compiler
- * @author    Nicolas Guilloux <nguilloux@richcongress.com>
- * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ * @author    Nicolas Guilloux <nicolas.guilloux@protonmail.com>
  */
 class DataTransferObjectPass implements CompilerPassInterface
 {

--- a/DependencyInjection/Compiler/DataTransferObjectPass.php
+++ b/DependencyInjection/Compiler/DataTransferObjectPass.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Chaplean\Bundle\DtoHandlerBundle\DependencyInjection\Compiler;
+
+use Chaplean\Bundle\DtoHandlerBundle\ParamConverter\DataTransferObjectParamConverter;
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Class DataTransferObjectPass
+ *
+ * @package   Chaplean\Bundle\DtoHandlerBundle\DependencyInjection\Compiler
+ * @author    Nicolas Guilloux <nguilloux@richcongress.com>
+ * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ */
+class DataTransferObjectPass implements CompilerPassInterface
+{
+    /**
+     * @param ContainerBuilder $container
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has(DataTransferObjectParamConverter::class)) {
+            return;
+        }
+
+        $definition = $container->findDefinition(DataTransferObjectParamConverter::class);
+        $taggedServices = $container->findTaggedServiceIds('app.data_transfer_object');
+
+        $definition->addMethodCall('setTaggedDtoServices', [$taggedServices]);
+    }
+}

--- a/Doc/DataTransferObject.md
+++ b/Doc/DataTransferObject.md
@@ -2,7 +2,7 @@
 
 ## Mandatory annotations
 
-To recognize the Data Transfer Object, the `ParamConverter` requires the class annotation `@DTO` to be set.
+To recognize the Data Transfer Object, the `ParamConverter` requires the class annotation `@DTO` to be set or the class to be tagged as `app.data_transfer_object`. Here, we only use the `DTO` annotation but you can find more information about the tag [here](ParamConverter.md#tagged-dto).
 
 To correctly extract the appropriate values to the variables, the `ParamConverter` requires to explicitly declare the type using the `Type` assertion of the Symfony validation component.
 
@@ -75,7 +75,7 @@ final class DummyDataTransferObject
 }
 ```
 
-An entity can be accepted using the `except` parameter which will tolerate to break the unicity restriction if the found entity is the same as the one in the `except`:
+An entity can be accepted using the `except` parameter which will tolerate to break the unicity restriction if the found entity is the same as the one in the `except`. The `except` option uses the Expression language, so `this` reffers to the DTO and `this.targetEntity` reffers to the value of the `$targetEntity` property.
 
 ```php
 /**
@@ -84,7 +84,7 @@ An entity can be accepted using the `except` parameter which will tolerate to br
  * @UniqueEntityData(
  *     fields={"property1", "property2"},
  *     entityClass="App\Entity\DummyEntity",
- *     except="targetEntity"
+ *     except="this.targetEntity"
  * )
  */
 final class DummyDataTransferObject

--- a/Doc/ParamConverter.md
+++ b/Doc/ParamConverter.md
@@ -2,6 +2,21 @@
 
 The `data_transfer_object_converter` maps all public variables from the DTO to the appropriate `ParamConverter`.
 
+## Tagged DTO
+
+To recognize the DTO, the ParamConverter required the `@DTO` annotation or the class to be tagged with `app.data_transfer_object`. To learn more about the annotation, please go [here](DataTransferObject.md#mandatory-annotations).
+
+To declare all classes in a folder as DTO, you can set the following configuration. For the concerned class, you will no longer need to set the `@DTO` annotation.
+
+```yaml
+services:
+    ...
+    
+    AppBundle\DataTransferObject\:
+        resource: '../src/AppBundle/DataTransferObject/*'
+        tags: ['app.data_transfer_object']
+```
+
 ## Validation
 
 ### Default behaviour

--- a/EventListener/DataTransferObjectValidationExceptionSubscriber.php
+++ b/EventListener/DataTransferObjectValidationExceptionSubscriber.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Chaplean\Bundle\DtoHandlerBundle\EventListener;
+
+use Chaplean\Bundle\DtoHandlerBundle\Exception\DataTransferObjectValidationException;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Class DataTransferObjectValidationExceptionSubscriber
+ *
+ * @package   Chaplean\Bundle\DtoHandlerBundle\EventListener
+ * @author    Nicolas Guilloux <nguilloux@richcongress.com>
+ * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ */
+class DataTransferObjectValidationExceptionSubscriber implements EventSubscriberInterface
+{
+    /**
+     * @return array
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            KernelEvents::EXCEPTION => 'onKernelException'
+        ];
+    }
+
+    /**
+     * @param GetResponseForExceptionEvent $event
+     *
+     * @return void
+     */
+    public function onKernelException(GetResponseForExceptionEvent $event): void
+    {
+        $exception = $event->getException();
+
+        if (!$exception instanceof DataTransferObjectValidationException) {
+            return;
+        }
+
+        $response = new JsonResponse(
+            $exception->getViolationsArray(),
+            $exception->getStatusCode()
+        );
+
+        $response->headers->set('Content-Type', 'application/problem+json');
+
+        $event->setResponse($response);
+    }
+}

--- a/EventListener/DataTransferObjectValidationExceptionSubscriber.php
+++ b/EventListener/DataTransferObjectValidationExceptionSubscriber.php
@@ -12,8 +12,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * Class DataTransferObjectValidationExceptionSubscriber
  *
  * @package   Chaplean\Bundle\DtoHandlerBundle\EventListener
- * @author    Nicolas Guilloux <nguilloux@richcongress.com>
- * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ * @author    Nicolas Guilloux <nicolas.guilloux@protonmail.com>
  */
 class DataTransferObjectValidationExceptionSubscriber implements EventSubscriberInterface
 {

--- a/Exception/DataTransferObjectValidationException.php
+++ b/Exception/DataTransferObjectValidationException.php
@@ -11,8 +11,7 @@ use Symfony\Component\Validator\ConstraintViolationListInterface;
  * Class DataTransferObjectValidationException
  *
  * @package   Chaplean\Bundle\DtoHandlerBundle\Exception
- * @author    Nicolas Guilloux <nguilloux@richcongress.com>
- * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ * @author    Nicolas Guilloux <nicolas.guilloux@protonmail.com>
  */
 class DataTransferObjectValidationException extends HttpException
 {

--- a/Exception/DataTransferObjectValidationException.php
+++ b/Exception/DataTransferObjectValidationException.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+namespace Chaplean\Bundle\DtoHandlerBundle\Exception;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+/**
+ * Class DataTransferObjectValidationException
+ *
+ * @package   Chaplean\Bundle\DtoHandlerBundle\Exception
+ * @author    Nicolas Guilloux <nguilloux@richcongress.com>
+ * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ */
+class DataTransferObjectValidationException extends HttpException
+{
+    /**
+     * @var ConstraintViolationListInterface
+     */
+    protected $violations;
+
+    /**
+     * DataTransferObjectValidationException constructor.
+     *
+     * @param ConstraintViolationListInterface $violations
+     */
+    public function __construct(ConstraintViolationListInterface $violations)
+    {
+        $this->violations = $violations;
+
+        parent::__construct(Response::HTTP_BAD_REQUEST);
+    }
+
+    /**
+     * @return ConstraintViolationListInterface
+     */
+    public function getViolations(): ConstraintViolationListInterface
+    {
+        return $this->violations;
+    }
+
+    /**
+     * @return array
+     */
+    public function getViolationsArray(): array
+    {
+        $errors = [];
+
+        /** @var ConstraintViolation $violation */
+        foreach ($this->violations as $violation) {
+            $errors[$violation->getPropertyPath()] = $violation->getMessage();
+        }
+
+        return $errors;
+    }
+}

--- a/ParamConverter/DataTransferObjectParamConverter.php
+++ b/ParamConverter/DataTransferObjectParamConverter.php
@@ -61,6 +61,7 @@ class DataTransferObjectParamConverter implements ParamConverterInterface
     ) {
         $this->manager = $paramConverterManager;
         $this->validator = $validator;
+        $this->taggedDtoClasses = [];
     }
 
     /**

--- a/ParamConverter/DataTransferObjectParamConverter.php
+++ b/ParamConverter/DataTransferObjectParamConverter.php
@@ -35,9 +35,9 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class DataTransferObjectParamConverter implements ParamConverterInterface
 {
     /**
-     * @var ContainerBuilder
+     * @var array
      */
-    protected $containerBuilder;
+    protected $taggedDtoClasses;
 
     /**
      * @var ParamConverterManager
@@ -52,18 +52,27 @@ class DataTransferObjectParamConverter implements ParamConverterInterface
     /**
      * DataTransferObjectParamConverter constructor.
      *
-     * @param ContainerBuilder        $containerBuilder
      * @param ParamConverterManager   $paramConverterManager
      * @param ValidatorInterface|null $validator
      */
     public function __construct(
-        ContainerBuilder $containerBuilder,
         ParamConverterManager $paramConverterManager,
         ValidatorInterface $validator = null
     ) {
-        $this->containerBuilder = $containerBuilder;
         $this->manager = $paramConverterManager;
         $this->validator = $validator;
+    }
+
+    /**
+     * @param array $taggedServices
+     *
+     * @return self
+     */
+    public function setTaggedDtoServices(array $taggedServices): self
+    {
+        $this->taggedDtoClasses = \array_keys($taggedServices);
+
+        return $this;
     }
 
     /**
@@ -117,9 +126,7 @@ class DataTransferObjectParamConverter implements ParamConverterInterface
             return false;
         }
 
-        $dtoServices = $this->containerBuilder->findTaggedServiceIds('app.data_transfer_object');
-
-        if (\array_key_exists($class, $dtoServices)) {
+        if (\in_array($class, $this->taggedDtoClasses, true)) {
             return true;
         }
 

--- a/ParamConverter/DataTransferObjectParamConverter.php
+++ b/ParamConverter/DataTransferObjectParamConverter.php
@@ -13,11 +13,13 @@ namespace Chaplean\Bundle\DtoHandlerBundle\ParamConverter;
 
 use Chaplean\Bundle\DtoHandlerBundle\Annotation\DTO;
 use Chaplean\Bundle\DtoHandlerBundle\ConfigurationExtractor\PropertyConfigurationExtractor;
+use Chaplean\Bundle\DtoHandlerBundle\Exception\DataTransferObjectValidationException;
 use Doctrine\Common\Annotations\AnnotationException;
 use Doctrine\Common\Annotations\AnnotationReader;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterInterface;
 use Sensio\Bundle\FrameworkExtraBundle\Request\ParamConverter\ParamConverterManager;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
 use Symfony\Component\Validator\ConstraintViolation;
@@ -33,25 +35,33 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
 class DataTransferObjectParamConverter implements ParamConverterInterface
 {
     /**
+     * @var ContainerBuilder
+     */
+    protected $containerBuilder;
+
+    /**
      * @var ParamConverterManager
      */
-    private $manager;
+    protected $manager;
 
     /**
      * @var ValidatorInterface
      */
-    private $validator;
+    protected $validator;
 
     /**
      * DataTransferObjectParamConverter constructor.
      *
+     * @param ContainerBuilder        $containerBuilder
      * @param ParamConverterManager   $paramConverterManager
      * @param ValidatorInterface|null $validator
      */
     public function __construct(
+        ContainerBuilder $containerBuilder,
         ParamConverterManager $paramConverterManager,
         ValidatorInterface $validator = null
     ) {
+        $this->containerBuilder = $containerBuilder;
         $this->manager = $paramConverterManager;
         $this->validator = $validator;
     }
@@ -101,11 +111,19 @@ class DataTransferObjectParamConverter implements ParamConverterInterface
      */
     public function supports(ParamConverter $configuration): bool
     {
-        if ($configuration->getClass() === null) {
+        $class = $configuration->getClass();
+
+        if ($class === null) {
             return false;
         }
 
-        $propertyReflectionClass = new \ReflectionClass($configuration->getClass());
+        $dtoServices = $this->containerBuilder->findTaggedServiceIds('app.data_transfer_object');
+
+        if (\array_key_exists($class, $dtoServices)) {
+            return true;
+        }
+
+        $propertyReflectionClass = new \ReflectionClass($class);
 
         $annotationReader = new AnnotationReader();
         $typeAnnotation = $annotationReader->getClassAnnotation($propertyReflectionClass, DTO::class);
@@ -296,14 +314,7 @@ class DataTransferObjectParamConverter implements ParamConverterInterface
         $violations = $this->validator->validate($object, null, $groups);
 
         if (!$validationHandler && $violations->count() > 0) {
-            $errors = [];
-
-            /** @var ConstraintViolation $violation */
-            foreach ($violations as $violation) {
-                $errors[$violation->getPropertyPath()] = $violation->getMessage();
-            }
-
-            throw new BadRequestHttpException(\json_encode($errors));
+            throw new DataTransferObjectValidationException($violations);
         }
 
         $request->attributes->set(

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This version of the bundle requires Symfony 3.4+.
 The dto-handler-bundle loads the content of a request into a Data Transfer Object (DTO), mapping its properties such as entities from the database.
 It uses the `ParamConverterInterface` provided by the [SensioLabs Framework Extra Bundle](https://symfony.com/doc/4.0/bundles/SensioFrameworkExtraBundle/index.html) to automatically map the request content to the appropriate variables.
 
+## Quick Start
+
 The dto-handler-bundle is simple to use as it requires almost no configuration. To use it in a controller, simply declare the variable in the controller's argument:
 
 ```php

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -13,5 +13,9 @@
         </service>
 
         <service id="Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator" />
+
+        <service id="Chaplean\Bundle\DtoHandlerBundle\EventListener\DataTransferObjectValidationExceptionSubscriber">
+            <tag name="kernel.event_subscriber" />
+        </service>
     </services>
 </container>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -9,6 +9,7 @@
 
         <service id="Chaplean\Bundle\DtoHandlerBundle\ParamConverter\DataTransferObjectParamConverter">
             <argument type="service" id="sensio_framework_extra.converter.manager" />
+            <argument type="service" id="validator" />
             <tag name="request.param_converter" converter="data_transfer_object_converter" />
         </service>
 

--- a/Tests/ConfigurationExtractor/PropertyConfigurationExtractorTest.php
+++ b/Tests/ConfigurationExtractor/PropertyConfigurationExtractorTest.php
@@ -7,7 +7,7 @@ use Doctrine\Common\Annotations\AnnotationException;
 use Mockery\Adapter\Phpunit\MockeryTestCase;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Entity\DummyEntity;
-use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Form\Data\DummyDataTransferObject;
+use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\DTO\DummyDataTransferObject;
 
 /**
  * Class PropertyConfigurationExtractorTest

--- a/Tests/EventListener/DataTransferObjectValidationExceptionSubscriberTest.php
+++ b/Tests/EventListener/DataTransferObjectValidationExceptionSubscriberTest.php
@@ -1,0 +1,109 @@
+<?php declare(strict_types=1);
+
+namespace Chaplean\Bundle\DtoHandlerBundle\Tests\EventListener;
+
+use Chaplean\Bundle\DtoHandlerBundle\EventListener\DataTransferObjectValidationExceptionSubscriber;
+use Chaplean\Bundle\DtoHandlerBundle\Exception\DataTransferObjectValidationException;
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * Class DataTransferObjectValidationExceptionSubscriberTest
+ *
+ * @package   Chaplean\Bundle\DtoHandlerBundle\Tests\EventListener
+ * @author    Nicolas Guilloux <nguilloux@richcongress.com>
+ * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ */
+class DataTransferObjectValidationExceptionSubscriberTest extends MockeryTestCase
+{
+    /**
+     * @var DataTransferObjectValidationExceptionSubscriber
+     */
+    protected $dataTransferObjectValidationExceptionSubscriber;
+
+    /**
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->dataTransferObjectValidationExceptionSubscriber = new DataTransferObjectValidationExceptionSubscriber();
+
+        parent::setUp();
+    }
+
+    /**
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\EventListener\DataTransferObjectValidationExceptionSubscriber::getSubscribedEvents()
+     *
+     * @return void
+     */
+    public function testGetSubscribedEvents(): void
+    {
+        self::assertArrayHasKey(
+            KernelEvents::EXCEPTION,
+            DataTransferObjectValidationExceptionSubscriber::getSubscribedEvents()
+        );
+
+        self::assertContains(
+            'onKernelException',
+            DataTransferObjectValidationExceptionSubscriber::getSubscribedEvents()
+        );
+    }
+
+    /**
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\EventListener\DataTransferObjectValidationExceptionSubscriber::onKernelException()
+     *
+     * @return void
+     */
+    public function testOnKernelExceptionWithAnotherException(): void
+    {
+        $exception = new BadRequestHttpException();
+
+        $event = \Mockery::mock(GetResponseForExceptionEvent::class);
+        $event->shouldNotReceive('setResponse');
+        $event->shouldReceive('getException')
+            ->once()
+            ->andReturn($exception);
+
+        $this->dataTransferObjectValidationExceptionSubscriber
+            ->onKernelException($event);
+    }
+
+    /**
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\EventListener\DataTransferObjectValidationExceptionSubscriber::onKernelException()
+     *
+     * @return void
+     */
+    public function testOnKernelException(): void
+    {
+        $violation1 = new ConstraintViolation('Bad Value 1', null, [], 'badValue1', 'violation1', 'badValue1');
+        $violation2 = new ConstraintViolation('Bad Value 2', null, [], 'badValue2', 'violation2', 'badValue2');
+
+        $violations = new ConstraintViolationList(
+            [
+                $violation1,
+                $violation2
+            ]
+        );
+
+        $exception = new DataTransferObjectValidationException($violations);
+
+        $event = \Mockery::mock(GetResponseForExceptionEvent::class);
+
+        $event->shouldReceive('getException')
+            ->once()
+            ->andReturn($exception);
+
+        $event->shouldReceive('setResponse')
+            ->once();
+
+        $this->dataTransferObjectValidationExceptionSubscriber
+            ->onKernelException($event);
+    }
+}

--- a/Tests/EventListener/DataTransferObjectValidationExceptionSubscriberTest.php
+++ b/Tests/EventListener/DataTransferObjectValidationExceptionSubscriberTest.php
@@ -18,8 +18,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
  * Class DataTransferObjectValidationExceptionSubscriberTest
  *
  * @package   Chaplean\Bundle\DtoHandlerBundle\Tests\EventListener
- * @author    Nicolas Guilloux <nguilloux@richcongress.com>
- * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ * @author    Nicolas Guilloux <nicolas.guilloux@protonmail.com>
  */
 class DataTransferObjectValidationExceptionSubscriberTest extends MockeryTestCase
 {

--- a/Tests/Exception/DataTransferObjectValidationExceptionTest.php
+++ b/Tests/Exception/DataTransferObjectValidationExceptionTest.php
@@ -1,0 +1,47 @@
+<?php declare(strict_types=1);
+
+namespace Chaplean\Bundle\DtoHandlerBundle\Tests\Exception;
+
+use Chaplean\Bundle\DtoHandlerBundle\Exception\DataTransferObjectValidationException;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\ConstraintViolation;
+use Symfony\Component\Validator\ConstraintViolationList;
+
+/**
+ * Class DataTransferObjectValidationExceptionTest
+ *
+ * @package   Chaplean\Bundle\DtoHandlerBundle\Tests\Exception
+ * @author    Nicolas Guilloux <nguilloux@richcongress.com>
+ * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ */
+class DataTransferObjectValidationExceptionTest extends TestCase
+{
+    /**
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Exception\DataTransferObjectValidationException::__construct()
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Exception\DataTransferObjectValidationException::getViolations()
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Exception\DataTransferObjectValidationException::getViolationsArray()
+     *
+     * @return void
+     */
+    public function testConstructorAndGetters(): void
+    {
+        $violation1 = new ConstraintViolation('Bad Value 1', null, [], 'badValue1', 'violation1', 'badValue1');
+        $violation2 = new ConstraintViolation('Bad Value 2', null, [], 'badValue2', 'violation2', 'badValue2');
+
+        $violations = new ConstraintViolationList(
+            [
+                $violation1,
+                $violation2
+            ]
+        );
+
+        $exception = new DataTransferObjectValidationException($violations);
+        $expectedArray = [
+            'violation1' => 'Bad Value 1',
+            'violation2' => 'Bad Value 2',
+        ];
+
+        self::assertSame($violations, $exception->getViolations());
+        self:self::assertEquals($expectedArray, $exception->getViolationsArray());
+    }
+}

--- a/Tests/Exception/DataTransferObjectValidationExceptionTest.php
+++ b/Tests/Exception/DataTransferObjectValidationExceptionTest.php
@@ -11,8 +11,7 @@ use Symfony\Component\Validator\ConstraintViolationList;
  * Class DataTransferObjectValidationExceptionTest
  *
  * @package   Chaplean\Bundle\DtoHandlerBundle\Tests\Exception
- * @author    Nicolas Guilloux <nguilloux@richcongress.com>
- * @copyright 2014 - 2019 RichCongress (https://www.richcongress.com)
+ * @author    Nicolas Guilloux <nicolas.guilloux@protonmail.com>
  */
 class DataTransferObjectValidationExceptionTest extends TestCase
 {

--- a/Tests/ParamConverter/DataTransferObjectParamConverterTest.php
+++ b/Tests/ParamConverter/DataTransferObjectParamConverterTest.php
@@ -41,11 +41,6 @@ class DataTransferObjectParamConverterTest extends MockeryTestCase
     private $dataTransferObjectParamConverter;
 
     /**
-     * @var ContainerBuilder|MockInterface
-     */
-    protected $containerBuilder;
-
-    /**
      * @var ParamConverterManager|MockInterface
      */
     private $manager;
@@ -62,14 +57,12 @@ class DataTransferObjectParamConverterTest extends MockeryTestCase
     {
         parent::setUp();
 
-        $this->containerBuilder = \Mockery::mock(ContainerBuilder::class);
         $this->manager = \Mockery::mock(ParamConverterManager::class);
         $this->validator = \Mockery::mock(ValidatorInterface::class);
 
         PHPMockery::mock('Chaplean\Bundle\DtoHandlerBundle\ParamConverter', 'uniqid')->andReturn('hash');
 
         $this->dataTransferObjectParamConverter = new DataTransferObjectParamConverter(
-            $this->containerBuilder,
             $this->manager,
             $this->validator
         );
@@ -87,6 +80,7 @@ class DataTransferObjectParamConverterTest extends MockeryTestCase
 
     /**
      * @covers \Chaplean\Bundle\DtoHandlerBundle\ParamConverter\DataTransferObjectParamConverter::supports()
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\ParamConverter\DataTransferObjectParamConverter::setTaggedDtoServices()
      *
      * @return void
      *
@@ -101,11 +95,8 @@ class DataTransferObjectParamConverterTest extends MockeryTestCase
             ]
         );
 
-        $this->containerBuilder
-            ->shouldReceive('findTaggedServiceIds')
-            ->once()
-            ->with('app.data_transfer_object')
-            ->andReturn(
+        $this->dataTransferObjectParamConverter
+            ->setTaggedDtoServices(
                 [
                     DummyDataTransferObject::class => 'app.data_transfer_object'
                 ]
@@ -130,12 +121,6 @@ class DataTransferObjectParamConverterTest extends MockeryTestCase
             ]
         );
 
-        $this->containerBuilder
-            ->shouldReceive('findTaggedServiceIds')
-            ->once()
-            ->with('app.data_transfer_object')
-            ->andReturn([]);
-
         self::assertTrue($this->dataTransferObjectParamConverter->supports($configurationSupported));
     }
 
@@ -154,12 +139,6 @@ class DataTransferObjectParamConverterTest extends MockeryTestCase
                 'class' => DummyEntity::class,
             ]
         );
-
-        $this->containerBuilder
-            ->shouldReceive('findTaggedServiceIds')
-            ->once()
-            ->with('app.data_transfer_object')
-            ->andReturn([]);
 
         self::assertFalse($this->dataTransferObjectParamConverter->supports($configurationUnsupported));
     }

--- a/Tests/Resources/DTO/DummyDataTransferObject.php
+++ b/Tests/Resources/DTO/DummyDataTransferObject.php
@@ -9,19 +9,19 @@
  * file that was distributed with this source code.
  */
 
-namespace Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Form\Data;
+namespace Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\DTO;
 
 use Chaplean\Bundle\DtoHandlerBundle\Annotation\DTO;
 use Chaplean\Bundle\DtoHandlerBundle\Annotation\MapTo;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
 use Symfony\Component\Validator\Constraints as Assert;
 use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Entity\DummyEntity;
-use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Form\Data\SubDataTransferObject;
+use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\DTO\SubDataTransferObject;
 
 /**
  * Class DummyDataTransferObject
  *
- * @package   Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Form\Data
+ * @package   Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\DTO
  * @author    Nicolas - Chaplean <nicolas@chaplean.coop>
  * @copyright 2014 - 2019 Chaplean (https://www.chaplean.coop)
  *
@@ -84,9 +84,24 @@ final class DummyDataTransferObject
      * @var SubDataTransferObject
      *
      * @Assert\All(
-     *     @Assert\Type("Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Form\Data\SubDataTransferObject")
+     *     @Assert\Type("Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\DTO\SubDataTransferObject")
      * )
      * @Assert\Valid
      */
     public $property7;
+
+    /**
+     * @var DummyEntity
+     *
+     * @Assert\NotNull
+     * @Assert\DateTime
+     */
+    public $property8;
+
+    /**
+     * @var DummyEntity
+     *
+     * @Assert\Date
+     */
+    public $property9;
 }

--- a/Tests/Resources/DTO/SubDataTransferObject.php
+++ b/Tests/Resources/DTO/SubDataTransferObject.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types=1);
 
-namespace Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Form\Data;
+namespace Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\DTO;
 
 use Chaplean\Bundle\DtoHandlerBundle\Annotation\DTO;
 use Symfony\Component\Validator\Constraints as Assert;
@@ -8,7 +8,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * Class SubDataTransferObject.
  *
- * @package   Chaplean\Bundle\DtoHandlerBundle\Tests\Resources\Form\Data
+ * @package   Chaplean\Bundle\DtoHandlerBundle\Tests\Resources\DTO
  * @author    Nicolas - Chaplean <nicolas@chaplean.coop>
  * @copyright 2014 - 2019 Chaplean (https://www.chaplean.coop)
  *

--- a/Tests/Utility/DtoUtilityTest.php
+++ b/Tests/Utility/DtoUtilityTest.php
@@ -1,0 +1,79 @@
+<?php declare(strict_types=1);
+
+namespace Chaplean\Bundle\DtoHandlerBundle\Tests\Utility;
+
+use Chaplean\Bundle\DtoHandlerBundle\Utility\DtoUtility;
+use Doctrine\Common\Collections\ArrayCollection;
+use PHPUnit\Framework\TestCase;
+use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Entity\DummyEntity;
+
+/**
+ * Class DtoUtilityTest
+ *
+ * @package Chaplean\Bundle\DtoHandlerBundle\Tests\Utility
+ * @author  Nicolas Guilloux <nicolas.guilloux@protonmail.com>
+ */
+class DtoUtilityTest extends TestCase
+{
+    /**
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Utility\DtoUtility::updateEntityList()
+     *
+     * @return void
+     */
+    public function testUpdateEntityListWithArrayCollection(): void
+    {
+        $entity1 = new DummyEntity();
+        $entity2 = new DummyEntity();
+        $entity3 = new DummyEntity();
+
+        $arrayCollection = new ArrayCollection([$entity1, $entity2]);
+        $updateArrayCollection = new ArrayCollection([$entity2, $entity3]);
+
+        $newArrayCollection = DtoUtility::updateEntityList($arrayCollection, $updateArrayCollection);
+
+        self::assertSame($newArrayCollection, $arrayCollection);
+        self::assertFalse($arrayCollection->contains($entity1));
+        self::assertTrue($arrayCollection->contains($entity2));
+        self::assertTrue($arrayCollection->contains($entity3));
+    }
+
+    /**
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Utility\DtoUtility::updateEntityList()
+     *
+     * @return void
+     */
+    public function testUpdateEntityListWithArray(): void
+    {
+        $entity1 = new DummyEntity();
+        $entity2 = new DummyEntity();
+        $entity3 = new DummyEntity();
+
+        $arrayCollection = new ArrayCollection([$entity1, $entity2]);
+        $updateArrayCollection = [$entity2, $entity3];
+
+        $newArrayCollection = DtoUtility::updateEntityList($arrayCollection, $updateArrayCollection);
+
+        self::assertSame($newArrayCollection, $arrayCollection);
+        self::assertFalse($arrayCollection->contains($entity1));
+        self::assertTrue($arrayCollection->contains($entity2));
+        self::assertTrue($arrayCollection->contains($entity3));
+    }
+
+    /**
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Utility\DtoUtility::updateEntityList()
+     *
+     * @return void
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage The new entity list must be an array or a Collection
+     */
+    public function testUpdateEntityListWithBadValue(): void
+    {
+        $entity1 = new DummyEntity();
+        $entity2 = new DummyEntity();
+
+        $arrayCollection = new ArrayCollection([$entity1, $entity2]);
+
+        DtoUtility::updateEntityList($arrayCollection, '');
+    }
+}

--- a/Tests/Validator/Constraints/UniqueEntityDataValidatorTest.php
+++ b/Tests/Validator/Constraints/UniqueEntityDataValidatorTest.php
@@ -20,7 +20,7 @@ use Mockery\MockInterface;
 use Symfony\Component\Validator\Context\ExecutionContext;
 use Symfony\Component\Validator\Violation\ConstraintViolationBuilderInterface;
 use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Entity\DummyEntity;
-use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\Form\Data\DummyDataTransferObject;
+use Tests\Chaplean\Bundle\DtoHandlerBundle\Resources\DTO\DummyDataTransferObject;
 
 /**
  * Class UniqueEntityDataValidatorTest
@@ -69,7 +69,6 @@ class UniqueEntityDataValidatorTest extends MockeryTestCase
     }
 
     /**
-     * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::__construct()
      * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::validate()
      *
      * @return void
@@ -97,6 +96,7 @@ class UniqueEntityDataValidatorTest extends MockeryTestCase
 
     /**
      * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::validate()
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::buildCriteria()
      *
      * @return void
      */
@@ -141,15 +141,13 @@ class UniqueEntityDataValidatorTest extends MockeryTestCase
 
     /**
      * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::validate()
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::buildCriteria()
      *
      * @return void
      */
     public function testValidateNotUniqueWithExcept(): void
     {
-        $entity = \Mockery::mock(DummyEntity::class);
-        $entity->shouldReceive('getId')
-            ->twice()
-            ->andReturn(1);
+        $entity = new DummyEntity();
 
         $dto = new DummyDataTransferObject();
         $dto->targetEntity = $entity;
@@ -160,7 +158,7 @@ class UniqueEntityDataValidatorTest extends MockeryTestCase
             [
                 'entityClass' => DummyEntity::class,
                 'fields'      => ['property1', 'property2'],
-                'except'      => 'targetEntity',
+                'except'      => 'this.targetEntity',
             ]
         );
 
@@ -182,6 +180,7 @@ class UniqueEntityDataValidatorTest extends MockeryTestCase
 
     /**
      * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::validate()
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::buildCriteria()
      *
      * @return void
      */
@@ -210,15 +209,13 @@ class UniqueEntityDataValidatorTest extends MockeryTestCase
 
     /**
      * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::validate()
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::buildCriteria()
      *
      * @return void
      */
     public function testValidateFieldObject(): void
     {
-        $entity = \Mockery::mock(DummyEntity::class);
-        $entity->shouldReceive('getId')
-            ->once()
-            ->andReturn(1);
+        $entity = new DummyEntity();
 
         $dto = new DummyDataTransferObject();
         $dto->property1 = 'Property 1';
@@ -248,6 +245,7 @@ class UniqueEntityDataValidatorTest extends MockeryTestCase
 
     /**
      * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::validate()
+     * @covers \Chaplean\Bundle\DtoHandlerBundle\Validator\Constraints\UniqueEntityDataValidator::buildCriteria()
      *
      * @return void
      */

--- a/Utility/DtoUtility.php
+++ b/Utility/DtoUtility.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types=1);
+
+namespace Chaplean\Bundle\DtoHandlerBundle\Utility;
+
+use Doctrine\Common\Collections\Collection;
+
+/**
+ * Class DtoUtility
+ *
+ * @package Chaplean\Bundle\DtoHandlerBundle\Utility
+ * @author  Nicolas Guilloux <nicolas.guilloux@protonmail.com>
+ */
+class DtoUtility
+{
+    /**
+     * @param Collection         $entityList
+     * @param \Traversable|array $newEntityList
+     *
+     * @return Collection
+     */
+    public static function updateEntityList(Collection $entityList, $newEntityList): Collection
+    {
+        if (!is_array($newEntityList) && !($newEntityList instanceof \Traversable)) {
+            throw new \InvalidArgumentException('The new entity list must be an array or a Collection');
+        }
+
+        foreach ($entityList as $value) {
+            $entityList->removeElement($value);
+        }
+
+        foreach ($newEntityList as $value) {
+            $entityList->add($value);
+        }
+
+        return $entityList;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "symfony/console": "^3.0 || ^4.0",
         "symfony/dependency-injection": "^3.0 || ^4.0",
         "symfony/validator": "^3.0 || ^4.0",
-        "symfony/expression-language": "^4.3"
+        "symfony/expression-language": "~2.7|~3.0|~4.0"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.2",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "symfony/config": "^3.0 || ^4.0",
         "symfony/console": "^3.0 || ^4.0",
         "symfony/dependency-injection": "^3.0 || ^4.0",
-        "symfony/validator": "^3.0 || ^4.0"
+        "symfony/validator": "^3.0 || ^4.0",
+        "symfony/expression-language": "^4.3"
     },
     "require-dev": {
         "mockery/mockery": "^1.2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5a9c7055707142b23cbb6f7189cf7b77",
+    "content-hash": "3b86c73885d65359e19fe9373d63beea",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -1618,6 +1618,57 @@
                 "standards"
             ],
             "time": "2019-05-22T12:23:29+00:00"
+        },
+        {
+            "name": "symfony/expression-language",
+            "version": "v4.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/expression-language.git",
+                "reference": "c8b47d8820d3bf75f757eec8a2647584c14cf0c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/expression-language/zipball/c8b47d8820d3bf75f757eec8a2647584c14cf0c6",
+                "reference": "c8b47d8820d3bf75f757eec8a2647584c14cf0c6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3",
+                "symfony/cache": "~3.4|~4.0",
+                "symfony/service-contracts": "^1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.3-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\ExpressionLanguage\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony ExpressionLanguage Component",
+            "homepage": "https://symfony.com",
+            "time": "2019-08-08T09:29:19+00:00"
         },
         {
             "name": "symfony/filesystem",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,6 +25,7 @@
 
             <exclude>
                 <file>phpunit-filter.php</file>
+                <file>ChapleanDtoHandlerBundle.php</file>
                 <directory>DependencyInjection</directory>
                 <directory>Resources</directory>
                 <directory>Tests</directory>


### PR DESCRIPTION
# 2.0.0

## New features:
 * Add a static function to update the Collection of entities with an input array.
 * Changing the `except` option for the `UniqueEntityData` constraint to support the Expression language.
 * In case of violations from the ParamConverter, the returned value is directly an array of violations instead of a message with the violations formatted in JSON.
 * It is possible to use the tag `app.data_transfer_object` to declare DTO instead of using the `@DTO` annotation.
 
## Breaking changes:
 * By changing the `except` option for the `UniqueEntityData` constraint, it is now mandatory to use `this` to target a property withing the DTO (e.g. `this.targetEntity`).
 * In case of violations, the returned value changed from a message with a JSON encoded string to an array of violations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/chaplean/dto-handler-bundle/3)
<!-- Reviewable:end -->
