### PR TITLE
Fix default value for the configuration key http_code_validation_groups

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -40,8 +40,10 @@ final class Configuration implements ConfigurationInterface
                 ->arrayNode('http_code_validation_groups')
                     ->info('Validate DTO with the the group and throw a HTTP exception with the mentioned status code in case of violations')
                     ->defaultValue([
-                        'validation_group' => 'Default',
-                        'http_status_code' => Response::HTTP_BAD_REQUEST,
+                        [
+                            'validation_group' => 'Default',
+                            'http_status_code' => Response::HTTP_BAD_REQUEST,
+                        ]
                     ])
                     ->arrayPrototype()
                         ->children()


### PR DESCRIPTION
There is an issue on projects using the default configuration, the default value for the key `validation_group` was not defined.

The default given in `Configuration.php` value was interpreted as an object with 2 keys, but what we actually wanted to express was an list of 1 object with 2 keys. This PR fixes that.