### PR TITLE
Add support for json payload in a file of a multipart body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.0
+
+New feature:
+ * The DTO handler can now also bind data from a json file in a multipart/form-data request. It now loads the content with the following priority: `Request > File > Attributes > Query`. The json file in the body is identified by the mime type `application/json` or `text/json`. The DTO handler will also remove these files from the Reques object to leave you with only the other files in your multipart body (such as uploaded images).
+
 ## 2.2.4
 
 Bug fix:

--- a/ParamConverter/DataTransferObjectParamConverter.php
+++ b/ParamConverter/DataTransferObjectParamConverter.php
@@ -505,7 +505,7 @@ class DataTransferObjectParamConverter implements ParamConverterInterface
      */
     private function extractDataFromMultipartBody(Request $request): void
     {
-        if ($request->headers->get('CONTENT_TYPE') !== 'multipart/form-data') {
+        if (explode(';', $request->headers->get('CONTENT_TYPE', ''))[0] !== 'multipart/form-data') {
             return;
         }
 

--- a/Tests/ParamConverter/DataTransferObjectParamConverterTest.php
+++ b/Tests/ParamConverter/DataTransferObjectParamConverterTest.php
@@ -880,7 +880,7 @@ class DataTransferObjectParamConverterTest extends MockeryTestCase
                 'otherIndependentFile' => $otherIndependentFile,
                 'invalidJsonFile'      => $invalidJsonFile,
             ],
-            ['CONTENT_TYPE' => 'multipart/form-data']
+            ['CONTENT_TYPE' => 'multipart/form-data; boundary=------------------------06b40b7b1fa902cb']
         );
 
         $configuration = new ParamConverter(


### PR DESCRIPTION
This allows you to send a multipart/form-data body containing one or more parts that are json files (identified by their mime type) and treat their content as regular json to build your DTOs from.

The motivation behind this is to be able to POST some data along with files to upload in a single request (and avoid encoding these files as base64 in the posted data for instance).

This PR only adds mention of this feature in the Changelog. Where could we document this feature?