### PR TITLE
Relax ext-json version requirement to allow php 7.4 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.3.4
+
+Bug fix:
+ * Relax ext-json version requirement to allow php 7.4 compatibility (ext-json versionning strategy changed to follow php version, so ext-json went from 1.5 to 7.4)
+
 ## 2.3.3
 
 New feature:

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require": {
         "php": ">=7.1",
-        "ext-json": "^1.5",
+        "ext-json": "*",
         "doctrine/annotations": "^1.6",
         "doctrine/orm": "^2.6",
         "sensio/framework-extra-bundle": "^5.0",


### PR DESCRIPTION
`ext-json` versionning strategy changed to follow php version.
As a consequence, when using php 7.4, `ext-json` version is 7.4 (it was 1.5 when using php 7.3).

This PR relaxes the version requirement to solve this issue and allow using this bundle with php 7.4.